### PR TITLE
Removed file extension in BASENAME so the script would work correctly.

### DIFF
--- a/mkoxt.sh
+++ b/mkoxt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 TMPZIP=/tmp/jsonparse.oxt
-IDLBASENAME=Xjsonparse.idl
+IDLBASENAME=Xjsonparse
 RDBFILE=jsonparse.rdb
 
 source mkoxt.sh.conf


### PR DESCRIPTION
Removed file extension in BASENAME so the script would work correctly on Debian 11. (Gets further in the process now but there are other errors I don't know how to fix.)